### PR TITLE
Update ViewsVideoLibrary.xml

### DIFF
--- a/720p/ViewsVideoLibrary.xml
+++ b/720p/ViewsVideoLibrary.xml
@@ -19,7 +19,8 @@
                     <texture>$VAR[poster]</texture>
                 </control>
                <control type="textbox">
-                    <visible>IsEmpty(ListItem.Art(poster))</visible>
+                    <visible>IsEmpty(ListItem.Art(thumb)) | [IsEmpty(ListItem.Art(fanart)) +  ![Container.Content(files)|Container.Content(tvshows)|Container.Content(movies)|Container.Content(musicvideos) |Container.Content(actors)|Container.Content(episodes)]]</visible>
+                   
                     <top>10</top>
                     <right>10</right>
                     <align>right</align>
@@ -39,7 +40,7 @@
                     <bordersize>4</bordersize>
                 </control>
                 <control type="textbox">
-                    <visible>IsEmpty(ListItem.Art(poster))</visible>
+                    <visible>IsEmpty(ListItem.Art(thumb)) | [IsEmpty(ListItem.Art(fanart)) +  ![Container.Content(files)|Container.Content(tvshows)|Container.Content(movies)|Container.Content(musicvideos) |Container.Content(actors)|Container.Content(episodes)]]</visible>
                     <top>10</top>
                     <right>10</right>
                     <align>right</align>


### PR DESCRIPTION
when in episodes view
name of the episodes show om top of the cover
with this
<visible>IsEmpty(ListItem.Art(thumb)) | [IsEmpty(ListItem.Art(fanart)) +  ![Container.Content(files)|Container.Content(tvshows)|Container.Content(movies)|Container.Content(musicvideos) |Container.Content(actors)|Container.Content(episodes)]]</visible>

it wont show anymore but if theire is no covers or actor pic the txt will show
